### PR TITLE
Add support to change the shutdown threshold.

### DIFF
--- a/battery/install
+++ b/battery/install
@@ -1,8 +1,10 @@
-
+#!/bin/bash
 sudo cp -vf oneUpPower.ko /lib/modules/`uname -r`/kernel/drivers/power/supply/oneUpPower.ko
+if ! grep -qF "oneUpPower" /etc/modules
+then
+    sudo sh -c 'echo "oneUpPower" >> /etc/modules'
+fi
+sudo sh -c 'echo "options oneUpPower soc_shutdown=5" > /etc/modprobe.d/oneUpPower.conf'
 sudo depmod -a
-ls /lib/modules/`uname -r`/kernel/drivers/power/supply/
 sudo insmod oneUpPower.ko
 sync
-
-

--- a/battery/remove
+++ b/battery/remove
@@ -1,1 +1,7 @@
+#!/bin/bash
 sudo rmmod oneUpPower
+sudo rm -vf /lib/modules/`uname -r`/kernel/drivers/power/supply/oneUpPower.ko
+sudo sh -c "sed -i '/oneUpPower/d' /etc/modules"
+sudo rm -vf /etc/modprobe.d/oneUpPower.conf
+sudo depmod -a
+sync


### PR DESCRIPTION
The default value for shutdown is less than 5% of battery life left. Once the system hits this value (or the one specified by the user) the system will shutdown.

The soc_shutdown value can be changed to 0 to disable this feature, just realise that the system will lose power and unsafely shutdown.

Also added install and remove functionality.