### PR TITLE
oneUpPower: log AC power state at boot

### DIFF
--- a/battery/ISSUES.md
+++ b/battery/ISSUES.md
@@ -56,15 +56,11 @@ the first I2C call returns an obscure error.
 
 ---
 
-### 5. `bat->status` stale at boot after initial AC read
+### ~~5. `bat->status` stale at boot after initial AC read~~ *(fixed)*
 
-**Location:** `oneup_battery_probe` (lines 611–615)
-
-After the boot-time AC read that corrects `bat->ac_online`, `bat->status` is
-never updated from its initial `POWER_SUPPLY_STATUS_DISCHARGING` value. If the
-charger is connected at boot, there is a brief window before the first workqueue
-fires where the AC supply reports `ONLINE=1` but the battery supply reports
-`DISCHARGING`. Fix: call `set_power_states(bat)` after the initial read.
+`set_power_states(bat)` is now called immediately after the boot-time AC read
+in `oneup_battery_probe`, so `bat->status` and `bat->capacity_level` are
+consistent with the real AC state before the power supplies are registered.
 
 ---
 

--- a/battery/oneUpPower.c
+++ b/battery/oneUpPower.c
@@ -28,7 +28,7 @@
 
 #define VERSION_MAJOR   1
 #define VERSION_MINOR   0
-#define VERSION_EDIT    4
+#define VERSION_EDIT    5
 
 
 #define TOTAL_LIFE_SECONDS          (6 * 60 * 60)
@@ -639,7 +639,10 @@ static int oneup_battery_probe(struct i2c_client *client)
 	if (ret >= 0) {
 		bat->ac_online    = ((ret & 0x80) == 0x80) ? 0 : 1;
 		bat->ac_candidate = bat->ac_online;
+		dev_info(&client->dev, "AC Power is %s at boot.\n",
+			 bat->ac_online ? "connected" : "not connected");
 	}
+	set_power_states(bat);
 
 	bat_cfg.drv_data = bat;
 	bat_cfg.fwnode   = dev_fwnode(&client->dev);


### PR DESCRIPTION
probe() read the real AC state before registering the power supplies (to avoid falsely reporting AC connected when booting on battery) but never logged the result.  Add a dev_info so the initial AC state is visible in dmesg alongside the SOC and profile messages.