### PR TITLE
oneUpPower: check REG_CONTROL read error in init_battery_profile

### DIFF
--- a/battery/ISSUES.md
+++ b/battery/ISSUES.md
@@ -2,24 +2,11 @@
 
 ## Medium Severity
 
-### 1. `init_battery_profile`: I2C read error on `REG_CONTROL` not handled
+### ~~1. `init_battery_profile`: I2C read error on `REG_CONTROL` not handled~~ *(fixed)*
 
-**Location:** `init_battery_profile` (line 336)
-
-```c
-control = i2c_smbus_read_byte_data(client, REG_CONTROL);
-if (control == 0) {
-```
-
-`i2c_smbus_read_byte_data` returns a negative error code on failure. A negative
-value is not zero, so any I2C error causes `profile_ok` to stay false and the
-function to fall through to the full profile-reprogram path — writing to the IC
-over a broken bus. The error should be checked and returned explicitly:
-
-```c
-if (control < 0)
-    return control;
-```
+`i2c_smbus_read_byte_data` on `REG_CONTROL` now checks for a negative return
+value and returns the error immediately, preventing a broken bus from silently
+falling through to the full profile-reprogram path.
 
 ---
 

--- a/battery/oneUpPower.c
+++ b/battery/oneUpPower.c
@@ -348,6 +348,10 @@ static int init_battery_profile(struct i2c_client *client)
 	// IC is active when REG_CONTROL reads back 0
 	//
 	control = i2c_smbus_read_byte_data(client, REG_CONTROL);
+	if (control < 0) {
+		dev_err(&client->dev, "Failed to read control register: %d\n", control);
+		return control;
+	}
 	if (control == 0) {
 		//
 		// IC is up; check if the profile-loaded flag is set


### PR DESCRIPTION
i2c_smbus_read_byte_data returns a negative errno on failure. The existing code only tested for control == 0 (IC active), so a bus error left control negative, skipped the profile-valid path, and fell through to the full 80-byte profile rewrite — issuing writes over a broken bus with no indication of the real cause.

Add an explicit < 0 check that logs the errno and returns it, letting probe() surface the failure to the I2C core cleanly.