### PR TITLE
oneUpPower: check write return values in restart_battery_ic

### DIFF
--- a/battery/ISSUES.md
+++ b/battery/ISSUES.md
@@ -10,19 +10,11 @@ falling through to the full profile-reprogram path.
 
 ---
 
-### 3. `restart_battery_ic`: write return values ignored in retry loop
+### ~~3. `restart_battery_ic`: write return values ignored in retry loop~~ *(fixed)*
 
-**Location:** `restart_battery_ic` (lines 288–291)
-
-```c
-i2c_smbus_write_byte_data(client, REG_CONTROL, CTRL_RESTART);
-msleep(500);
-i2c_smbus_write_byte_data(client, REG_CONTROL, CTRL_ACTIVE);
-```
-
-Both writes are fire-and-forget. Bus errors go unreported and the loop burns the
-full 18-second retry budget (3 attempts × 6 seconds each) before returning
-`-ETIMEDOUT`, with no indication of the real cause.
+Both `CTRL_RESTART` and `CTRL_ACTIVE` writes now check the return value. A
+negative errno is logged and returned immediately — a broken bus no longer
+burns the full 18-second retry budget before surfacing the real error.
 
 ---
 

--- a/battery/oneUpPower.c
+++ b/battery/oneUpPower.c
@@ -297,12 +297,21 @@ static int restart_battery_ic(struct i2c_client *client)
 	int icstate;
 	int attempt;
 	int wait;
+	int ret;
 
 	for (attempt = 0; attempt < 3; attempt++) {
-		i2c_smbus_write_byte_data(client, REG_CONTROL, CTRL_RESTART);
+		ret = i2c_smbus_write_byte_data(client, REG_CONTROL, CTRL_RESTART);
+		if (ret < 0) {
+			dev_err(&client->dev, "Failed to write CTRL_RESTART: %d\n", ret);
+			return ret;
+		}
 		msleep(500);
 
-		i2c_smbus_write_byte_data(client, REG_CONTROL, CTRL_ACTIVE);
+		ret = i2c_smbus_write_byte_data(client, REG_CONTROL, CTRL_ACTIVE);
+		if (ret < 0) {
+			dev_err(&client->dev, "Failed to write CTRL_ACTIVE: %d\n", ret);
+			return ret;
+		}
 		msleep(500);
 
 		for (wait = 0; wait < 5; wait++) {


### PR DESCRIPTION
Both i2c_smbus_write_byte_data calls (CTRL_RESTART and CTRL_ACTIVE) were fire-and-forget. A bus error left the return value discarded, so the retry loop burned the full 18-second budget (3 attempts x 6 seconds each) before returning -ETIMEDOUT with no indication of the real cause.

Check each write; on failure log the errno and return immediately.