### PR TITLE
oneUpPower: verify SMBUS byte-data support in probe

### DIFF
--- a/battery/ISSUES.md
+++ b/battery/ISSUES.md
@@ -18,20 +18,11 @@ burns the full 18-second retry budget before surfacing the real error.
 
 ---
 
-### 4. Missing `i2c_check_functionality` in probe
+### ~~4. Missing `i2c_check_functionality` in probe~~ *(fixed)*
 
-**Location:** `oneup_battery_probe` (before first I2C call)
-
-The driver never verifies the adapter supports `I2C_FUNC_SMBUS_BYTE_DATA` before
-issuing SMBUS calls. Standard Linux I2C driver practice:
-
-```c
-if (!i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_BYTE_DATA))
-    return -EOPNOTSUPP;
-```
-
-Without this, the driver binds to adapters that can't fulfill its requests and
-the first I2C call returns an obscure error.
+`oneup_battery_probe` now calls `i2c_check_functionality` for
+`I2C_FUNC_SMBUS_BYTE_DATA` as its first action and returns `-EOPNOTSUPP`
+immediately if the adapter cannot fulfill SMBUS byte-data requests.
 
 ---
 

--- a/battery/oneUpPower.c
+++ b/battery/oneUpPower.c
@@ -624,6 +624,9 @@ static int oneup_battery_probe(struct i2c_client *client)
 	struct power_supply_config ac_cfg = {};
 	int ret;
 
+	if (!i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_BYTE_DATA))
+		return -EOPNOTSUPP;
+
 	bat = devm_kzalloc(&client->dev, sizeof(*bat), GFP_KERNEL);
 	if (!bat)
 		return -ENOMEM;


### PR DESCRIPTION
The driver never checked that the I2C adapter supports I2C_FUNC_SMBUS_BYTE_DATA before issuing SMBUS calls. Binding to an incompatible adapter produced an obscure error on the first I2C transaction rather than a clean refusal at probe time.

Add i2c_check_functionality as the first action in probe, returning -EOPNOTSUPP immediately if the adapter cannot fulfill byte-data requests.