### PR TITLE
oneUpPower: fix all low-severity issues (#7–11)

### DIFF
--- a/battery/ISSUES.md
+++ b/battery/ISSUES.md
@@ -2,39 +2,7 @@
 
 ## Medium Severity
 
-### ~~1. `init_battery_profile`: I2C read error on `REG_CONTROL` not handled~~ *(fixed)*
-
-`i2c_smbus_read_byte_data` on `REG_CONTROL` now checks for a negative return
-value and returns the error immediately, preventing a broken bus from silently
-falling through to the full profile-reprogram path.
-
----
-
-### ~~3. `restart_battery_ic`: write return values ignored in retry loop~~ *(fixed)*
-
-Both `CTRL_RESTART` and `CTRL_ACTIVE` writes now check the return value. A
-negative errno is logged and returned immediately — a broken bus no longer
-burns the full 18-second retry budget before surfacing the real error.
-
----
-
-### ~~4. Missing `i2c_check_functionality` in probe~~ *(fixed)*
-
-`oneup_battery_probe` now calls `i2c_check_functionality` for
-`I2C_FUNC_SMBUS_BYTE_DATA` as its first action and returns `-EOPNOTSUPP`
-immediately if the adapter cannot fulfill SMBUS byte-data requests.
-
----
-
-### ~~5. `bat->status` stale at boot after initial AC read~~ *(fixed)*
-
-`set_power_states(bat)` is now called immediately after the boot-time AC read
-in `oneup_battery_probe`, so `bat->status` and `bat->capacity_level` are
-consistent with the real AC state before the power supplies are registered.
-
----
-
-### 6. Hardcoded `VOLTAGE_NOW` and `TEMP` return fake values *(partially fixed)*
+### 1. Hardcoded `VOLTAGE_NOW` and `TEMP` return fake values *(partially fixed)*
 
 `POWER_SUPPLY_PROP_TEMP` and `POWER_SUPPLY_PROP_VOLTAGE_NOW` have been removed
 from `power_battery_props[]` and their `case` branches dropped. Userspace now
@@ -70,68 +38,3 @@ Use `tools/cw2217_probe.py` to dump raw register values from a live system
 and cross-check against a known voltage (multimeter on the battery terminals)
 and known temperature to reverse-engineer the scaling if the datasheet is
 unavailable.
-
----
-
-## Low Severity
-
-### 7. `sprintf` used in module parameter getter
-
-**Location:** `param_get_soc_shutdown` (line 697)
-
-```c
-return sprintf(buffer, "%d", soc_shutdown);
-```
-
-The kernel convention for sysfs/param callbacks is `sysfs_emit(buffer, ...)` (kernel 5.10+) or
-at minimum `scnprintf`. Plain `sprintf` has no bounds checking on the provided buffer.
-
----
-
-### 8. `module_param` declarations appear after `module_i2c_driver()`
-
-**Location:** lines 670 vs. 706
-
-`module_i2c_driver` expands to `module_init`/`module_exit`. Placing `module_param` and its
-supporting ops struct after this macro is unconventional. Parameter declarations should
-appear before the driver registration macro.
-
----
-
-### 9. `REG_SOCALERT` write clobbers alert threshold bits
-
-**Location:** `init_battery_profile` (line 396)
-
-```c
-i2c_smbus_write_byte_data(client, REG_SOCALERT, 0x80);
-```
-
-The entire register is written as `0x80` without a read-modify-write. If the CW2217 uses
-lower bits of `REG_SOCALERT` for SOC alert thresholds, they are silently zeroed.
-
----
-
-### 10. `POWER_SUPPLY_PROP_CHARGE_TYPE` always returns `FAST`
-
-**Location:** `oneup_bat_get_property` (line 496)
-
-```c
-case POWER_SUPPLY_PROP_CHARGE_TYPE:
-    val->intval = POWER_SUPPLY_CHARGE_TYPE_FAST;
-```
-
-When the battery is discharging this should return `POWER_SUPPLY_CHARGE_TYPE_NONE`.
-Returning `FAST` while discharging misleads power managers and desktop environments.
-
----
-
-### 11. `TIME_TO_FULL_NOW` / `TIME_TO_EMPTY_AVG` ignore charging state
-
-**Location:** `oneup_bat_get_property` (lines 524–529)
-
-- `TIME_TO_EMPTY_AVG` returns a non-zero value even when AC is connected and the
-  battery is full — there is no meaningful time-to-empty while charging.
-- `TIME_TO_FULL_NOW` returns a non-zero value even while discharging — there is no
-  meaningful time-to-full while draining.
-
-Both should return `0` in the inapplicable direction.

--- a/battery/oneUpPower.c
+++ b/battery/oneUpPower.c
@@ -416,9 +416,12 @@ static int init_battery_profile(struct i2c_client *client)
 	}
 
 	//
-	// Mark profile as loaded
+	// Mark profile as loaded — RMW to preserve lower SOC alert threshold bits
 	//
-	ret = i2c_smbus_write_byte_data(client, REG_SOCALERT, 0x80);
+	socalert = i2c_smbus_read_byte_data(client, REG_SOCALERT);
+	if (socalert < 0)
+		socalert = 0;
+	ret = i2c_smbus_write_byte_data(client, REG_SOCALERT, (u8)socalert | 0x80);
 	if (ret < 0) {
 		dev_err(&client->dev, "Failed to set profile flag: %d\n", ret);
 		return ret;
@@ -531,7 +534,9 @@ static int oneup_bat_get_property(struct power_supply *psy,
 		val->intval = status;
 		break;
 	case POWER_SUPPLY_PROP_CHARGE_TYPE:
-		val->intval = POWER_SUPPLY_CHARGE_TYPE_FAST;
+		val->intval = (status == POWER_SUPPLY_STATUS_CHARGING)
+			? POWER_SUPPLY_CHARGE_TYPE_FAST
+			: POWER_SUPPLY_CHARGE_TYPE_NONE;
 		break;
 	case POWER_SUPPLY_PROP_HEALTH:
 		val->intval = POWER_SUPPLY_HEALTH_GOOD;
@@ -559,10 +564,12 @@ static int oneup_bat_get_property(struct power_supply *psy,
 		val->intval = TOTAL_CHARGE;
 		break;
 	case POWER_SUPPLY_PROP_TIME_TO_EMPTY_AVG:
-		val->intval = soc * TOTAL_LIFE_SECONDS / 100;
+		val->intval = (status == POWER_SUPPLY_STATUS_DISCHARGING)
+			? soc * TOTAL_LIFE_SECONDS / 100 : 0;
 		break;
 	case POWER_SUPPLY_PROP_TIME_TO_FULL_NOW:
-		val->intval = (100 - soc) * TOTAL_CHARGE_FULL_SECONDS / 100;
+		val->intval = (status == POWER_SUPPLY_STATUS_CHARGING)
+			? (100 - soc) * TOTAL_CHARGE_FULL_SECONDS / 100 : 0;
 		break;
 	case POWER_SUPPLY_PROP_MODEL_NAME:
 		val->strval = "oneUp Battery";
@@ -696,17 +703,6 @@ static const struct i2c_device_id oneup_battery_i2c_id[] = {
 };
 MODULE_DEVICE_TABLE(i2c, oneup_battery_i2c_id);
 
-static struct i2c_driver oneup_battery_driver = {
-	.driver = {
-		.name           = "oneup-battery",
-		.of_match_table = oneup_battery_of_match,
-		.pm             = &oneup_battery_pm_ops,
-	},
-	.probe    = oneup_battery_probe,
-	.id_table = oneup_battery_i2c_id,
-};
-module_i2c_driver(oneup_battery_driver);
-
 static int param_set_soc_shutdown(const char *key, const struct kernel_param *kp)
 {
 	long soc;
@@ -732,7 +728,7 @@ static int param_set_soc_shutdown(const char *key, const struct kernel_param *kp
 
 static int param_get_soc_shutdown(char *buffer, const struct kernel_param *kp)
 {
-	return sprintf(buffer, "%d", soc_shutdown);
+	return scnprintf(buffer, PAGE_SIZE, "%d\n", soc_shutdown);
 }
 
 static const struct kernel_param_ops param_ops_soc_shutdown = {
@@ -746,6 +742,17 @@ MODULE_PARM_DESC(soc_shutdown, "Shutdown system when the battery state of charge
 
 module_param(ac_debounce_polls, int, 0644);
 MODULE_PARM_DESC(ac_debounce_polls, "Number of consecutive polls (1-10) to confirm AC state change (default 3).");
+
+static struct i2c_driver oneup_battery_driver = {
+	.driver = {
+		.name           = "oneup-battery",
+		.of_match_table = oneup_battery_of_match,
+		.pm             = &oneup_battery_pm_ops,
+	},
+	.probe    = oneup_battery_probe,
+	.id_table = oneup_battery_i2c_id,
+};
+module_i2c_driver(oneup_battery_driver);
 
 MODULE_DESCRIPTION("Power supply driver for Argon40 1UP");
 MODULE_AUTHOR("Jeff Curless <jeff@thecurlesses.com>");


### PR DESCRIPTION
- Replace sprintf with scnprintf(PAGE_SIZE) in param_get_soc_shutdown to match kernel parameter getter convention and bound the output.
- Move module_param declarations and their supporting ops struct to before module_i2c_driver(), following kernel convention.
- Use read-modify-write on REG_SOCALERT when setting the profile-loaded flag, preserving any lower SOC alert threshold bits instead of overwriting the full register with 0x80.
- Return POWER_SUPPLY_CHARGE_TYPE_NONE when not charging; previously FAST was returned unconditionally, misleading power managers.
- Return 0 for TIME_TO_EMPTY_AVG while charging and 0 for TIME_TO_FULL_NOW while discharging — both values are meaningless in the inapplicable direction.