### PR TITLE
battery: fix DKMS autoinstall being skipped on kernel updates

### DIFF
--- a/battery/lib.sh
+++ b/battery/lib.sh
@@ -40,18 +40,39 @@ detect_distro() {
 }
 
 ensure_kernel_headers() {
-    local kernel_release
+    local kernel_release flavor meta apt_updated=0
     kernel_release="$(uname -r)"
+
+    detect_distro
+
+    # On Raspberry Pi OS the versioned headers are pulled in by a flavor
+    # metapackage (linux-headers-rpi-2712, linux-headers-rpi-v8, ...).  If that
+    # metapackage is missing, headers stop tracking kernel updates and DKMS
+    # autoinstall is skipped at upgrade time with "kernel headers for this
+    # kernel do not seem to be installed" — the module is then absent after
+    # rebooting into the new kernel.  Installing only the versioned headers
+    # package fixes the current kernel but not the next update, so make sure
+    # the metapackage itself is installed.
+    if [[ "$DISTRO_FAMILY" == "debian" && "$kernel_release" == *"+rpt-rpi-"* ]]; then
+        flavor="${kernel_release##*+rpt-}"
+        meta="linux-headers-${flavor}"
+        if ! dpkg-query -W -f '${Status}' "$meta" 2>/dev/null | grep -q 'install ok installed'; then
+            echo "Headers metapackage ${meta} is not installed."
+            echo "Installing it so kernel headers (and DKMS builds) follow future kernel updates..."
+            sudo apt-get update
+            apt_updated=1
+            sudo apt-get install -y "$meta"
+        fi
+    fi
 
     if [[ -d "/lib/modules/${kernel_release}/build" ]]; then
         return 0
     fi
 
-    detect_distro
     case "$DISTRO_FAMILY" in
         debian)
             echo "Kernel headers for ${kernel_release} not found; installing linux-headers-${kernel_release}..."
-            sudo apt-get update
+            [[ "$apt_updated" -eq 1 ]] || sudo apt-get update
             sudo apt-get install -y "linux-headers-${kernel_release}"
             ;;
         *)

--- a/battery/setupdkms
+++ b/battery/setupdkms
@@ -26,8 +26,11 @@ fi
 # Also remove the dkms tree entry directly. `dkms add` fails with "DKMS tree
 # already contains: oneUpPower/1.0" if /var/lib/dkms/oneUpPower/1.0 still
 # exists, which can happen even after `dkms remove --all` if it left behind
-# a stale directory for a kernel whose build tree no longer exists.
-sudo rm -rf "/var/lib/dkms/oneUpPower/${DKMS_VERSION}"
+# a stale directory for a kernel whose build tree no longer exists.  Remove
+# the whole module directory, not just the version subtree — dkms keeps
+# kernel-<ver>-<arch> symlinks as siblings of the version directory, and
+# removing only the subtree leaves them dangling.
+sudo rm -rf "/var/lib/dkms/oneUpPower"
 # Also remove the source tree — dkms add fails if the directory already exists
 # even when no dkms registration is present (e.g. after a partial run).
 if [ -d "$DKMS_DEST" ]; then


### PR DESCRIPTION
DKMS was not rebuilding oneUpPower when the kernel was updated, but running setupdkms manually after reboot always worked. Investigation of /var/log/apt/term.log showed the DKMS configuration itself is correct: autoinstall ran and succeeded for the rpi-v8 flavor on every upgrade, but was skipped for the rpi-2712 flavor (the kernel a Pi 5 boots) with:

  "Automatic installation of modules for kernel <ver>+rpt-rpi-2712 was
   skipped since the kernel headers for this kernel do not seem to be
   installed."

Root cause: the linux-headers-rpi-2712 metapackage had been removed, so versioned 2712 headers no longer arrived with kernel updates and the DKMS kernel-postinst hook had nothing to build against. setupdkms "fixed" it each time because ensure_kernel_headers installed the versioned headers for the then-running kernel — which repairs the current kernel but not the next update.

Changes:

- lib.sh: ensure_kernel_headers() now detects Raspberry Pi OS kernels (*+rpt-rpi-*), derives the flavor (rpi-2712, rpi-v8, ...), and installs the matching linux-headers-<flavor> metapackage if missing, so headers — and therefore DKMS autoinstall — track future kernel updates. The versioned-headers fallback for the running kernel is kept for non-Pi kernels and partial states.

- setupdkms: remove the whole /var/lib/dkms/oneUpPower directory when re-registering instead of only the 1.0 subtree. dkms keeps kernel-<ver>-<arch> symlinks as siblings of the version directory; removing only the subtree left them dangling.

One-time system fix (also applied automatically by re-running setupdkms): sudo apt install linux-headers-rpi-2712